### PR TITLE
Send Message with cmd+Enter on macOS

### DIFF
--- a/src/sites/desktop/common/scripts/timeline-core.ls
+++ b/src/sites/desktop/common/scripts/timeline-core.ls
@@ -144,8 +144,8 @@ class Post
 					THIS.upload-new-file file
 
 		# Ctrl + Enter
-		THIS.$reply-form.find 'textarea' .keypress (e) ->
-			if (e.char-code == 10 || e.char-code == 13) && e.ctrl-key
+		THIS.$reply-form.find 'textarea' .keydown (e) ->
+			if (e.key-code == 10 || e.key-code == 13) && (e.ctrl-key || e.meta-key)
 				THIS.submit-reply!
 
 		THIS.$reply-form.find '.attach-from-album' .click ->

--- a/src/sites/desktop/common/scripts/ui.ls
+++ b/src/sites/desktop/common/scripts/ui.ls
@@ -462,8 +462,8 @@ class StatusPostForm
 		THIS.$textarea.bind \input ->
 			$ \#misskey-post-form .find \.submit-button .attr \disabled off
 
-		THIS.$textarea.keypress (e) ->
-			if (e.char-code == 10 || e.char-code == 13) && e.ctrl-key
+		THIS.$textarea.keydown (e) ->
+			if (e.key-code == 10 || e.key-code == 13) && (e.ctrl-key || e.meta-key)
 				THIS.submit!
 
 		THIS.$textarea.on \paste (event) ->

--- a/src/sites/desktop/pages/i/talk/main.ls
+++ b/src/sites/desktop/pages/i/talk/main.ls
@@ -95,8 +95,8 @@ $ ->
 		text = $ '#post-form textarea' .val!
 		socket.emit \type text
 
-	$ '#post-form textarea' .keypress (e) ->
-		if (e.char-code == 10 || e.char-code == 13) && e.ctrl-key
+	$ '#post-form textarea' .keydown (e) ->
+		if (e.key-code == 10 || e.key-code == 13) && (e.ctrl-key || e.meta-key)
 			send-message!
 
 	$ '#post-form textarea' .on \paste (event) ->

--- a/src/sites/desktop/pages/post/script.ls
+++ b/src/sites/desktop/pages/post/script.ls
@@ -81,8 +81,8 @@ class Post
 						file = item.get-as-file!
 						upload-new-file file
 
-			..find 'textarea' .keypress (e) ->
-				if (e.char-code == 10 || e.char-code == 13) && e.ctrl-key
+			..find 'textarea' .keydown (e) ->
+				if (e.key-code == 10 || e.key-code == 13) && (e.ctrl-key || e.meta-key)
 					submit-reply!
 
 			..find '.attach-from-album' .click ->

--- a/src/sites/mobile/pages/i/talk/main.ls
+++ b/src/sites/mobile/pages/i/talk/main.ls
@@ -71,8 +71,8 @@ $ ->
 		text = $ '#post-form textarea' .val!
 		socket.emit \type text
 
-	$ '#post-form textarea' .keypress (e) ->
-		if (e.char-code == 10 || e.char-code == 13) && e.ctrl-key
+	$ '#post-form textarea' .keydown (e) ->
+		if (e.key-code == 10 || e.key-code == 13) && (e.ctrl-key || e.meta-key)
 			send-message!
 
 	$ '#post-form textarea' .on \paste (event) ->


### PR DESCRIPTION
Cmd+Enterで送信できるようにした